### PR TITLE
Improve readability of active_editors.sql syntax

### DIFF
--- a/queries/active_editors.sql
+++ b/queries/active_editors.sql
@@ -3,10 +3,6 @@ WITH global_user_registration AS (
         user_name,
         MIN(CAST(TRUNC(user_registration, 'MONTH') AS DATE)) AS global_registration_month
     FROM wmf_product.editor_month
-    WHERE
-        user_id != 0
-        AND NOT bot_by_group
-        AND user_name NOT REGEXP 'bot\\b'
     GROUP BY
         user_name
 ),
@@ -19,7 +15,7 @@ aggregated_edits AS (
     FROM wmf_product.editor_month e
     INNER JOIN global_user_registration g ON e.user_name = g.user_name
     WHERE
-        e.MONTH = '{metrics_month_first_day}'
+        e.month = '{metrics_month_first_day}'
         AND e.user_id != 0
         AND NOT e.bot_by_group
         AND e.user_name NOT REGEXP 'bot\\b'
@@ -31,8 +27,8 @@ aggregated_edits AS (
 SELECT
     month,
     COUNT(*) AS active_editors,
-    SUM(CAST(global_registration_month = CAST(month AS DATE) AS INT)) AS new_active_editors,
-    COUNT(*) - SUM(CAST(global_registration_month = CAST(month AS DATE) AS INT)) AS returning_active_editors
+    COUNT_IF(global_registration_month = CAST(month AS DATE)) AS new_active_editors,
+    COUNT(*) - COUNT_IF(global_registration_month = CAST(month AS DATE)) AS returning_active_editors
 FROM
     aggregated_edits
 WHERE


### PR DESCRIPTION
Replaced sum(cast(x as int)) with count_if to streamline readability in the final SELECT statement.
Corrected e.MONTH to e.month.
Kept only one instance of anonymous and bot filtering 'where' clauses to improve readability.
Bug: T358684